### PR TITLE
Fix build failure with updated gems

### DIFF
--- a/jekyll-theme-dracula.gemspec
+++ b/jekyll-theme-dracula.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   end
 
   s.platform      = Gem::Platform::RUBY
-  s.add_runtime_dependency "jekyll", "~> 3.5"
-  s.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
+  s.add_runtime_dependency "jekyll", "~> 3.9"
+  s.add_runtime_dependency "jekyll-seo-tag", "~> 2.7.1"
 end


### PR DESCRIPTION
Current jekyll-seo-tag version relies on jekyll 3.1. Updating both of these should work. Adding non-versioned jekyll-seo-tag plugin to config.yml is a confirmed fix, but following current standards for this gemspec.