### PR TITLE
Add: Support for `details` and `summary` marker

### DIFF
--- a/_sass/jekyll-theme-dracula.scss
+++ b/_sass/jekyll-theme-dracula.scss
@@ -185,6 +185,47 @@ button, a.button {
   }
 }
 
+details {
+  &>summary {
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::before {
+      content: "▷";
+      padding-inline-end: 8px;
+    }
+  }
+}
+
+details[open] {
+  &>summary {
+    &::before {
+      content: "▽";
+    }
+  }
+}
+
+[dir="rtl"] {
+  details {
+    &>summary {
+      &::before {
+        content: "◁";
+      }
+    }
+  }
+
+  details[open] {
+    &>summary {
+      &::before {
+        content: "▽";
+      }
+    }
+  }
+}
+
 
 #header {
   z-index: 100;


### PR DESCRIPTION
This also supports right-to-left layout. A inline padding of `8px` is added at the end of the marker.
#### Screennshots:
![Screenshot from 2022-06-10 09-27-41](https://user-images.githubusercontent.com/43103163/172987617-094df10c-e853-4bce-95e6-9faccbe3206a.png)
`rtl` layout
![Screenshot from 2022-06-10 09-28-16](https://user-images.githubusercontent.com/43103163/172987624-45d71a1c-4b5d-48d8-8713-d4393b878fa6.png)

